### PR TITLE
Import all Subroutine files

### DIFF
--- a/PySpacely/Master_Config.py
+++ b/PySpacely/Master_Config.py
@@ -36,7 +36,8 @@ try:
     #     modules_to_try = [TARGET_CONFIG_MOD, TARGET_SUBROUTINES_MOD, TARGET_ROUTINES_MOD]
     
     # find all submodules
-    subroutines = glob.glob("spacely-asic-config/CMSPIX28Spacely/CMSPIX28Spacely_Subroutines*.py")
+    subroutines = os.path.join("spacely-asic-config",TARGET,f"{TARGET}_Subroutines*.py")
+    subroutines = glob.glob(subroutines)
     subroutine_modules = [i.replace("/",".").strip(".py") for i in subroutines]
     modules_to_try = [TARGET_CONFIG_MOD] + subroutine_modules + [TARGET_ROUTINES_MOD]
     print(f"{TARGET} has the following modules: ", modules_to_try)

--- a/PySpacely/Master_Config.py
+++ b/PySpacely/Master_Config.py
@@ -1,6 +1,7 @@
 # SPACELY MASTER CONFIGURATION #
 import importlib
 import os
+import glob
 
 #Global software settings
 VERBOSE = True
@@ -10,13 +11,13 @@ PROGRESS = True
 USE_ARDUINO = False
 USE_NI = False
 
-TARGET = "SPROCKET3A"
+TARGET = "CMSPIX28Spacely"
 
 TARGET_ROUTINES_MOD = f"spacely-asic-config.{TARGET}.{TARGET}_Routines"
 TARGET_ROUTINES_PY = os.path.join("spacely-asic-config",TARGET,f"{TARGET}_Routines.py")  
 
-TARGET_SUBROUTINES_MOD = f"spacely-asic-config.{TARGET}.{TARGET}_Subroutines"
-TARGET_SUBROUTINES_PY = os.path.join("spacely-asic-config",TARGET,f"{TARGET}_Subroutines.py")
+# TARGET_SUBROUTINES_MOD = f"spacely-asic-config.{TARGET}.{TARGET}_Subroutines"
+# TARGET_SUBROUTINES_PY = os.path.join("spacely-asic-config",TARGET,f"{TARGET}_Subroutines.py")
 
 TARGET_CONFIG_MOD = f"spacely-asic-config.{TARGET}.{TARGET}_Config"
 TARGET_CONFIG_PY = os.path.join("spacely-asic-config",TARGET,f"{TARGET}_Routines.py")  
@@ -28,12 +29,17 @@ try:
     # Deep Python Magic which is basically equivalent to doing "from {module_name} import *"
     # where {module_name} is dynamically determined at runtime. We do this twice, once for 
     # ASIC_Config.py and once for ASIC_Routines.py.
-    modules_to_try = [TARGET_CONFIG_MOD, TARGET_ROUTINES_MOD]
-    if os.path.exists(TARGET_SUBROUTINES_PY):
-        print(f"{TARGET} has a subroutines file, loading...")
-        #Be sure load subroutines before routines.
-        modules_to_try = [TARGET_CONFIG_MOD, TARGET_SUBROUTINES_MOD, TARGET_ROUTINES_MOD]
-        
+    # modules_to_try = [TARGET_CONFIG_MOD, TARGET_ROUTINES_MOD]
+    # if os.path.exists(TARGET_SUBROUTINES_PY):
+    #     print(f"{TARGET} has a subroutines file, loading...")
+    #     #Be sure load subroutines before routines.
+    #     modules_to_try = [TARGET_CONFIG_MOD, TARGET_SUBROUTINES_MOD, TARGET_ROUTINES_MOD]
+    
+    # find all submodules
+    subroutines = glob.glob("spacely-asic-config/CMSPIX28Spacely/CMSPIX28Spacely_Subroutines*.py")
+    subroutine_modules = [i.replace("/",".").strip(".py") for i in subroutines]
+    modules_to_try = [TARGET_CONFIG_MOD] + subroutine_modules + [TARGET_ROUTINES_MOD]
+    print(f"{TARGET} has the following modules: ", modules_to_try)
 
     for module_name in modules_to_try:
 

--- a/PySpacely/Master_Config.py
+++ b/PySpacely/Master_Config.py
@@ -37,8 +37,8 @@ try:
     
     # find all submodules
     subroutines = os.path.join("spacely-asic-config",TARGET,f"{TARGET}_Subroutines*.py")
-    subroutines = glob.glob(subroutines)
-    subroutine_modules = [i.replace("/",".").strip(".py") for i in subroutines]
+    subroutines = list(sorted(glob.glob(subroutines)))
+    subroutine_modules = [i.replace("/",".")[:-3] for i in subroutines]
     modules_to_try = [TARGET_CONFIG_MOD] + subroutine_modules + [TARGET_ROUTINES_MOD]
     print(f"{TARGET} has the following modules: ", modules_to_try)
 


### PR DESCRIPTION
Import all files with name like `f"{TARGET}_Subroutines*.py"` rather than just a single Subroutine file. This allows the user to organize code into different subroutine files. CMSPIX28 is finding this very useful.